### PR TITLE
Add conversions from other color formats

### DIFF
--- a/BETA.js
+++ b/BETA.js
@@ -49,8 +49,8 @@
         toString: function ()
         {
             return (this.a >= 1) ?
-                "rgb(" + this.r + "," + this.g + "," + this.b + ")" :
-                "rgba(" + this.r + "," + this.g + "," + this.b + "," + this.a + ")";
+                "rgb(" + this.r + ", " + this.g + ", " + this.b + ")" :
+                "rgba(" + this.r + ", " + this.g + ", " + this.b + ", " + this.a + ")";
         }
     };
 

--- a/BETA.js
+++ b/BETA.js
@@ -159,8 +159,11 @@
     BETA.hwba = function (hue, whiteness, blackness, alpha)
     {
         var h = BETA.mod(hue, 360) / 60;
-        var w = BETA.clamp(whiteness, 0, 1);
-        var b = BETA.clamp(blackness, 0, 1);
+        var w = Math.max(0, whiteness);
+        var b = Math.max(0, blackness);
+        var sum = w + b;
+        if (sum > 1) { w = w / sum; b = b / sum; }
+
         var red;
         var green;
         var blue;

--- a/BETA.js
+++ b/BETA.js
@@ -36,7 +36,7 @@
     }
     
     //Clamps val to the range [a, b]
-    BETA.clamp(val, a, b)
+    BETA.clamp = function (val, a, b)
     {
         return a < b ?
             Math.max(a, Math.min(b, val)) :
@@ -96,7 +96,6 @@
         hue = BETA.mod(hue, 360) / 360;
         saturation = BETA.clamp(saturation, 0, 1);
         lightness = BETA.clamp(lightness, 0, 1);
-        alpha = BETA.clamp(alpha, 0, 1);
         var r;
         var g;
         var b;

--- a/BETA.js
+++ b/BETA.js
@@ -11,6 +11,22 @@
     "use strict";
     window.BETA = {};
 
+    BETA.assert = function (assertion, message)
+    {
+        if (!assertion)
+        {
+            var msg = (message) ?
+                "Assertion failed: " + message :
+                "Assertion failed.";
+            throw new Error(msg);
+        }
+    }
+
+    BETA.isNumber = function (val)
+    {
+        return (typeof val === "number" && !isNaN(val));
+    }
+
     //------------COLOR FUNCTIONS-----------\\
 
     BETA.colorProto = {

--- a/BETA.js
+++ b/BETA.js
@@ -102,7 +102,7 @@
 
         if (saturation == 0)
         {
-            r = g = b = l; // achromatic
+            r = g = b = (l * 255); // achromatic
         }
         else
         {

--- a/BETA.js
+++ b/BETA.js
@@ -154,6 +154,39 @@
         return BETA.hsva(hue, saturation, value, 1);
     }
 
+    //Adapted from http://alvyray.com/Papers/CG/hwb2rgb.htm
+    BETA.hwba = function (hue, whiteness, blackness, alpha)
+    {
+        var h = BETA.mod(hue, 360) / 60;
+        var w = BETA.zeroOneClamp(whiteness);
+        var b = BETA.zeroOneClamp(blackness);
+        var red;
+        var green;
+        var blue;
+
+        var v = 1 - b;
+        var i = Math.floor(h);
+        var f = h - i;
+        if (i % 2) { f = 1 - f; }
+        var n = w + f * (v - w);
+
+        switch (i)
+        {
+            case 0: red = v; green = n; blue = w; break;
+            case 1: red = n; green = v; blue = w; break;
+            case 2: red = w; green = v; blue = n; break;
+            case 3: red = w; green = n; blue = v; break;
+            case 4: red = n; green = w; blue = v; break;
+            case 5: red = v; green = w; blue = n; break
+        }
+        return BETA.rgba(red * 255, green * 255, blue * 255);
+    }
+
+    BETA.hwb = function (hue, whiteness, blackness)
+    {
+        return BETA.hwba(hue, whiteness, blackness);
+    }
+
     //------------VECTOR FUNCTIONS------------\\
 
     BETA.vProto = {

--- a/BETA.js
+++ b/BETA.js
@@ -77,12 +77,15 @@
     //https://gist.github.com/mjackson/5311256
     BETA.hueToRgbChannel = function (p, q, t)
     {
-        if (t < 0) t += 1;
-        if (t > 1) t -= 1;
-        if (t < 1 / 6) return p + (q - p) * 6 * t;
-        if (t < 1 / 2) return q;
-        if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
-        return p * 255;
+        var ret;
+        if (t < 0) { t += 1; }
+        if (t > 1) { t -= 1; }
+
+        if (t < 1 / 6) { ret = (p + (q - p) * 6 * t); }
+        else if (t < 1 / 2) { ret = q; }
+        else if (t < 2 / 3) { ret = (p + (q - p) * (2 / 3 - t) * 6); }
+        else { ret = p; }
+        return ret * 255;
     }
 
     BETA.hsla = function (hue, saturation, lightness, alpha)
@@ -143,7 +146,7 @@
             case 5: r = value; g = p; b = q; break;
         }
 
-        return BETA.rgba(r * 255, b * 255, c * 255, alpha);
+        return BETA.rgba(r * 255, b * 255, g * 255, alpha);
     }
 
     BETA.hsv = function (hue, saturation, value)

--- a/BETA.js
+++ b/BETA.js
@@ -125,7 +125,6 @@
         hue = BETA.mod(hue, 360) / 360;
         saturation = BETA.zeroOneClamp(saturation);
         value = BETA.zeroOneClamp(value);
-        alpha = BETA.zeroOneClamp(alpha);
         var r;
         var g;
         var b;

--- a/BETA.js
+++ b/BETA.js
@@ -168,7 +168,7 @@
         var v = 1 - b;
         var i = Math.floor(h);
         var f = h - i;
-        if (i % 2) { f = 1 - f; }
+        if (i % 2) {f = 1 - f;}
         var n = w + f * (v - w);
 
         switch (i)
@@ -178,14 +178,14 @@
             case 2: red = w; green = v; blue = n; break;
             case 3: red = w; green = n; blue = v; break;
             case 4: red = n; green = w; blue = v; break;
-            case 5: red = v; green = w; blue = n; break
+            case 5: red = v; green = w; blue = n; break;
         }
-        return BETA.rgba(red * 255, green * 255, blue * 255);
+        return BETA.rgba(red * 255, green * 255, blue * 255, alpha);
     }
 
     BETA.hwb = function (hue, whiteness, blackness)
     {
-        return BETA.hwba(hue, whiteness, blackness);
+        return BETA.hwba(hue, whiteness, blackness, 1);
     }
 
     //------------VECTOR FUNCTIONS------------\\

--- a/BETA.js
+++ b/BETA.js
@@ -73,7 +73,7 @@
         return BETA.rgba(red, green, blue, 1);
     }
 
-    //HSL and HSV conversions made by GitHub user mjackson
+    //HSL conversion made by GitHub user mjackson
     //https://gist.github.com/mjackson/5311256
     BETA.hueToRgbChannel = function (p, q, t)
     {
@@ -120,32 +120,33 @@
         return BETA.hsla(hue, saturation, lightness, 1);
     }
 
+    //Adapted from http://alvyray.com/Papers/CG/hsv2rgb.htm
     BETA.hsva = function (hue, saturation, value, alpha)
     {
-        hue = BETA.mod(hue, 360) / 360;
-        saturation = BETA.zeroOneClamp(saturation);
-        value = BETA.zeroOneClamp(value);
-        var r;
-        var g;
-        var b;
+        var h = BETA.mod(hue, 360) / 60;
+        var s = BETA.zeroOneClamp(saturation);
+        var v = BETA.zeroOneClamp(value);
+        var red;
+        var green;
+        var blue;
 
-        var i = Math.floor(hue * 6);
-        var f = hue * 6 - i;
-        var p = value * (1 - saturation);
-        var q = value * (1 - f * saturation);
-        var t = value * (1 - (1 - f) * saturation);
+        var i = Math.floor(h);
+        var f = h - i;
+        if (i % 2 === 0) { f = 1 - f; }
+        var m = v * (1 - s);
+        var n = v * (1 - s * f);
 
-        switch (i % 6)
+        switch (i)
         {
-            case 0: r = value; g = t; b = p; break;
-            case 1: r = q; g = value; b = p; break;
-            case 2: r = p; g = value; b = t; break;
-            case 3: r = p; g = q; b = value; break;
-            case 4: r = t; g = p; b = value; break;
-            case 5: r = value; g = p; b = q; break;
+            case 0: red = v; green = n; blue = m; break;
+            case 1: red = n; green = v; blue = m; break;
+            case 2: red = m; green = v; blue = n; break;
+            case 3: red = m; green = n; blue = v; break;
+            case 4: red = n; green = m; blue = v; break;
+            case 5: red = v; green = m; blue = n; break;
         }
 
-        return BETA.rgba(r * 255, b * 255, g * 255, alpha);
+        return BETA.rgba(red * 255, green * 255, blue * 255, alpha);
     }
 
     BETA.hsv = function (hue, saturation, value)

--- a/BETA.js
+++ b/BETA.js
@@ -11,6 +11,8 @@
     "use strict";
     window.BETA = {};
 
+    //------------COLOR FUNCTIONS-----------\\
+
     BETA.colorProto = {
         toString: function ()
         {
@@ -35,7 +37,75 @@
         return BETA.rgba(red, green, blue, 1);
     }
 
+    //HSL and HSV conversions made by GitHub user mjackson
+    //https://gist.github.com/mjackson/5311256
+    BETA.hueToRgbChannel = function (p, q, t)
+    {
+        if (t < 0) t += 1;
+        if (t > 1) t -= 1;
+        if (t < 1 / 6) return p + (q - p) * 6 * t;
+        if (t < 1 / 2) return q;
+        if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+        return p * 255;
+    }
 
+    BETA.hsla = function (h, s, l, a)
+    {
+        var r;
+        var g;
+        var b;
+
+        if (s == 0)
+        {
+            r = g = b = l; // achromatic
+        }
+        else
+        {
+            var q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+            var p = 2 * l - q;
+
+            r = BETA.hueToRgbChannel(p, q, h + 1 / 3);
+            g = BETA.hueToRgbChannel(p, q, h);
+            b = BETA.hueToRgbChannel(p, q, h - 1 / 3);
+        }
+
+        return BETA.rgba(r, g, b, a);
+    }
+
+    BETA.hsl = function (h, s, l)
+    {
+        return BETA.hsla(h, s, l, 1);
+    }
+
+    BETA.hsva = function (h, s, v, a)
+    {
+        var r;
+        var g;
+        var b;
+
+        var i = Math.floor(h * 6);
+        var f = h * 6 - i;
+        var p = v * (1 - s);
+        var q = v * (1 - f * s);
+        var t = v * (1 - (1 - f) * s);
+
+        switch (i % 6)
+        {
+            case 0: r = v, g = t, b = p; break;
+            case 1: r = q, g = v, b = p; break;
+            case 2: r = p, g = v, b = t; break;
+            case 3: r = p, g = q, b = v; break;
+            case 4: r = t, g = p, b = v; break;
+            case 5: r = v, g = p, b = q; break;
+        }
+
+        return BETA.rgba(r * 255, b * 255, c * 255, a);
+    }
+
+    BETA.hsv = function (h, s, v)
+    {
+        return BETA.hsva(h, s, v, 1);
+    }
 
     //------------VECTOR FUNCTIONS------------\\
 

--- a/BETA.js
+++ b/BETA.js
@@ -22,13 +22,25 @@
         }
     };
 
+    BETA.rgbChannelConform = function (val)
+    {
+        return Math.max(0, Math.min(255, Math.round(val)));
+    }
+
+    BETA.zeroOneClamp = function (val)
+    {
+        return Math.max(0, Math.min(1, val));
+    }
+
     BETA.rgba = function (red, green, blue, alpha)
     {
+        alpha = (alpha !== undefined) ? alpha : 1;
+
         var color = Object.create(BETA.colorProto);
-        color.r = red;
-        color.g = green;
-        color.b = blue;
-        color.a = (alpha !== undefined) ? alpha : 1;
+        color.r = BETA.rgbChannelConform(red);
+        color.g = BETA.rgbChannelConform(green);
+        color.b = BETA.rgbChannelConform(blue);
+        color.a = BETA.zeroOneClamp(alpha);
         return color;
     }
 
@@ -51,6 +63,10 @@
 
     BETA.hsla = function (h, s, l, a)
     {
+        h = BETA.zeroOneClamp(h);
+        s = BETA.zeroOneClamp(s);
+        l = BETA.zeroOneClamp(l);
+        a = BETA.zeroOneClamp(a);
         var r;
         var g;
         var b;
@@ -79,6 +95,10 @@
 
     BETA.hsva = function (h, s, v, a)
     {
+        h = BETA.zeroOneClamp(h);
+        s = BETA.zeroOneClamp(s);
+        v = BETA.zeroOneClamp(v);
+        a = BETA.zeroOneClamp(a);
         var r;
         var g;
         var b;

--- a/BETA.js
+++ b/BETA.js
@@ -27,6 +27,14 @@
         return (typeof val === "number" && !isNaN(val));
     }
 
+    BETA.mod = function (x, y)
+    {
+        var r = x % y;
+        return r < 0 ?
+            r + y :
+            r + 0; //adding +0 ensures no negative zeroes
+    }
+
     //------------COLOR FUNCTIONS-----------\\
 
     BETA.colorProto = {

--- a/BETA.js
+++ b/BETA.js
@@ -34,6 +34,14 @@
             r + y :
             r + 0; //adding +0 ensures no negative zeroes
     }
+    
+    //Clamps val to the range [a, b]
+    BETA.clamp(val, a, b)
+    {
+        return a < b ?
+            Math.max(a, Math.min(b, val)) :
+            Math.max(b, Math.min(a, val));
+    }
 
     //------------COLOR FUNCTIONS-----------\\
 
@@ -51,11 +59,6 @@
         return Math.max(0, Math.min(255, Math.round(val)));
     }
 
-    BETA.zeroOneClamp = function (val)
-    {
-        return Math.max(0, Math.min(1, val));
-    }
-
     BETA.rgba = function (red, green, blue, alpha)
     {
         alpha = (alpha !== undefined) ? alpha : 1;
@@ -64,7 +67,7 @@
         color.r = BETA.rgbChannelConform(red);
         color.g = BETA.rgbChannelConform(green);
         color.b = BETA.rgbChannelConform(blue);
-        color.a = BETA.zeroOneClamp(alpha);
+        color.a = BETA.clamp(alpha, 0, 1);
         return color;
     }
 
@@ -91,9 +94,9 @@
     BETA.hsla = function (hue, saturation, lightness, alpha)
     {
         hue = BETA.mod(hue, 360) / 360;
-        saturation = BETA.zeroOneClamp(saturation);
-        lightness = BETA.zeroOneClamp(lightness);
-        alpha = BETA.zeroOneClamp(alpha);
+        saturation = BETA.clamp(saturation, 0, 1);
+        lightness = BETA.clamp(lightness, 0, 1);
+        alpha = BETA.clamp(alpha, 0, 1);
         var r;
         var g;
         var b;
@@ -124,8 +127,8 @@
     BETA.hsva = function (hue, saturation, value, alpha)
     {
         var h = BETA.mod(hue, 360) / 60;
-        var s = BETA.zeroOneClamp(saturation);
-        var v = BETA.zeroOneClamp(value);
+        var s = BETA.clamp(saturation, 0, 1);
+        var v = BETA.clamp(value, 0, 1);
         var red;
         var green;
         var blue;
@@ -145,7 +148,6 @@
             case 4: red = n; green = m; blue = v; break;
             case 5: red = v; green = m; blue = n; break;
         }
-
         return BETA.rgba(red * 255, green * 255, blue * 255, alpha);
     }
 
@@ -158,8 +160,8 @@
     BETA.hwba = function (hue, whiteness, blackness, alpha)
     {
         var h = BETA.mod(hue, 360) / 60;
-        var w = BETA.zeroOneClamp(whiteness);
-        var b = BETA.zeroOneClamp(blackness);
+        var w = BETA.clamp(whiteness, 0, 1);
+        var b = BETA.clamp(blackness, 0, 1);
         var red;
         var green;
         var blue;

--- a/BETA.js
+++ b/BETA.js
@@ -85,70 +85,70 @@
         return p * 255;
     }
 
-    BETA.hsla = function (h, s, l, a)
+    BETA.hsla = function (hue, saturation, lightness, alpha)
     {
-        h = BETA.mod(h, 360) / 360;
-        s = BETA.zeroOneClamp(s);
-        l = BETA.zeroOneClamp(l);
-        a = BETA.zeroOneClamp(a);
+        hue = BETA.mod(hue, 360) / 360;
+        saturation = BETA.zeroOneClamp(saturation);
+        lightness = BETA.zeroOneClamp(lightness);
+        alpha = BETA.zeroOneClamp(alpha);
         var r;
         var g;
         var b;
 
-        if (s == 0)
+        if (saturation == 0)
         {
-            r = g = b = l; // achromatic
+            r = g = b = lightness; // achromatic
         }
         else
         {
-            var q = l < 0.5 ? l * (1 + s) : l + s - l * s;
-            var p = 2 * l - q;
+            var q = lightness < 0.5 ? lightness * (1 + saturation) : lightness + saturation - lightness * saturation;
+            var p = 2 * lightness - q;
 
-            r = BETA.hueToRgbChannel(p, q, h + 1 / 3);
-            g = BETA.hueToRgbChannel(p, q, h);
-            b = BETA.hueToRgbChannel(p, q, h - 1 / 3);
+            r = BETA.hueToRgbChannel(p, q, hue + 1 / 3);
+            g = BETA.hueToRgbChannel(p, q, hue);
+            b = BETA.hueToRgbChannel(p, q, hue - 1 / 3);
         }
 
-        return BETA.rgba(r, g, b, a);
+        return BETA.rgba(r, g, b, alpha);
     }
 
-    BETA.hsl = function (h, s, l)
+    BETA.hsl = function (hue, saturation, lightness)
     {
-        return BETA.hsla(h, s, l, 1);
+        return BETA.hsla(hue, saturation, lightness, 1);
     }
 
-    BETA.hsva = function (h, s, v, a)
+    BETA.hsva = function (hue, saturation, value, alpha)
     {
-        h = BETA.mod(h, 360) / 360;
-        s = BETA.zeroOneClamp(s);
-        v = BETA.zeroOneClamp(v);
-        a = BETA.zeroOneClamp(a);
+        hue = BETA.mod(hue, 360) / 360;
+        saturation = BETA.zeroOneClamp(saturation);
+        value = BETA.zeroOneClamp(value);
+        alpha = BETA.zeroOneClamp(alpha);
         var r;
         var g;
         var b;
 
-        var i = Math.floor(h * 6);
-        var f = h * 6 - i;
-        var p = v * (1 - s);
-        var q = v * (1 - f * s);
-        var t = v * (1 - (1 - f) * s);
+        var i = Math.floor(hue * 6);
+        var f = hue * 6 - i;
+        var p = value * (1 - saturation);
+        var q = value * (1 - f * saturation);
+        var t = value * (1 - (1 - f) * saturation);
 
         switch (i % 6)
         {
-            case 0: r = v; g = t; b = p; break;
-            case 1: r = q; g = v; b = p; break;
-            case 2: r = p; g = v; b = t; break;
-            case 3: r = p; g = q; b = v; break;
-            case 4: r = t; g = p; b = v; break;
-            case 5: r = v; g = p; b = q; break;
+            case 0: r = value; g = t; b = p; break;
+            case 1: r = q; g = value; b = p; break;
+            case 2: r = p; g = value; b = t; break;
+            case 3: r = p; g = q; b = value; break;
+            case 4: r = t; g = p; b = value; break;
+            case 5: r = value; g = p; b = q; break;
         }
 
-        return BETA.rgba(r * 255, b * 255, c * 255, a);
+        return BETA.rgba(r * 255, b * 255, c * 255, alpha);
     }
 
-    BETA.hsv = function (h, s, v)
+    BETA.hsv = function (hue, saturation, value)
     {
-        return BETA.hsva(h, s, v, 1);
+        return BETA.hsva(hue, saturation, value, 1);
     }
 
     //------------VECTOR FUNCTIONS------------\\

--- a/BETA.js
+++ b/BETA.js
@@ -87,7 +87,7 @@
 
     BETA.hsla = function (h, s, l, a)
     {
-        h = BETA.zeroOneClamp(h);
+        h = BETA.mod(h, 360) / 360;
         s = BETA.zeroOneClamp(s);
         l = BETA.zeroOneClamp(l);
         a = BETA.zeroOneClamp(a);
@@ -119,7 +119,7 @@
 
     BETA.hsva = function (h, s, v, a)
     {
-        h = BETA.zeroOneClamp(h);
+        h = BETA.mod(h, 360) / 360;
         s = BETA.zeroOneClamp(s);
         v = BETA.zeroOneClamp(v);
         a = BETA.zeroOneClamp(a);
@@ -135,12 +135,12 @@
 
         switch (i % 6)
         {
-            case 0: r = v, g = t, b = p; break;
-            case 1: r = q, g = v, b = p; break;
-            case 2: r = p, g = v, b = t; break;
-            case 3: r = p, g = q, b = v; break;
-            case 4: r = t, g = p, b = v; break;
-            case 5: r = v, g = p, b = q; break;
+            case 0: r = v; g = t; b = p; break;
+            case 1: r = q; g = v; b = p; break;
+            case 2: r = p; g = v; b = t; break;
+            case 3: r = p; g = q; b = v; break;
+            case 4: r = t; g = p; b = v; break;
+            case 5: r = v; g = p; b = q; break;
         }
 
         return BETA.rgba(r * 255, b * 255, c * 255, a);

--- a/BETA.js
+++ b/BETA.js
@@ -93,25 +93,25 @@
 
     BETA.hsla = function (hue, saturation, lightness, alpha)
     {
-        hue = BETA.mod(hue, 360) / 360;
-        saturation = BETA.clamp(saturation, 0, 1);
-        lightness = BETA.clamp(lightness, 0, 1);
+        var h = BETA.mod(hue, 360) / 360;
+        var s = BETA.clamp(saturation / 100, 0, 1);
+        var l = BETA.clamp(lightness / 100, 0, 1);
         var r;
         var g;
         var b;
 
         if (saturation == 0)
         {
-            r = g = b = lightness; // achromatic
+            r = g = b = l; // achromatic
         }
         else
         {
-            var q = lightness < 0.5 ? lightness * (1 + saturation) : lightness + saturation - lightness * saturation;
-            var p = 2 * lightness - q;
+            var q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+            var p = 2 * l - q;
 
-            r = BETA.hueToRgbChannel(p, q, hue + 1 / 3);
-            g = BETA.hueToRgbChannel(p, q, hue);
-            b = BETA.hueToRgbChannel(p, q, hue - 1 / 3);
+            r = BETA.hueToRgbChannel(p, q, h + 1 / 3);
+            g = BETA.hueToRgbChannel(p, q, h);
+            b = BETA.hueToRgbChannel(p, q, h - 1 / 3);
         }
 
         return BETA.rgba(r, g, b, alpha);
@@ -126,8 +126,8 @@
     BETA.hsva = function (hue, saturation, value, alpha)
     {
         var h = BETA.mod(hue, 360) / 60;
-        var s = BETA.clamp(saturation, 0, 1);
-        var v = BETA.clamp(value, 0, 1);
+        var s = BETA.clamp(saturation / 100, 0, 1);
+        var v = BETA.clamp(value / 100, 0, 1);
         var red;
         var green;
         var blue;
@@ -159,8 +159,8 @@
     BETA.hwba = function (hue, whiteness, blackness, alpha)
     {
         var h = BETA.mod(hue, 360) / 60;
-        var w = Math.max(0, whiteness);
-        var b = Math.max(0, blackness);
+        var w = Math.max(0, whiteness / 100);
+        var b = Math.max(0, blackness / 100);
         var sum = w + b;
         if (sum > 1) { w = w / sum; b = b / sum; }
 


### PR DESCRIPTION
While RGB is the main format for computer graphics, it is not intuitive to humans.
HSL, HSV and HWB are far more intuitive formats, while still fast-to-convert enough for the relatively high performance requirements of real-time graphics.
