### PR TITLE
Add image API

### DIFF
--- a/BETA.js
+++ b/BETA.js
@@ -284,7 +284,7 @@
 
     var onAllLoaded = null;
 
-    BETA.waitForImgLoad(callback)
+    BETA.waitForImgLoad = function (callback)
     {
         if (loadingImgs === 0)
         {
@@ -309,7 +309,7 @@
         this.width = cvs.width;
         this.height = cvs.height;
         this.sizeVector = BETA.v(cvs.width, cvs.height);
-    };
+    }
 
     BETA.Canvas.prototype.resize = function (x, y)
     {
@@ -320,7 +320,7 @@
         this.canvas.height = y;
         this.canvas.style.width = x + "px";
         this.canvas.style.height = y + "px";
-    };
+    }
 
     BETA.Canvas.prototype.vectorResize = function (vector)
     {
@@ -331,7 +331,7 @@
         this.canvas.height = vector.y;
         this.canvas.style.width = vector.x + "px";
         this.canvas.style.height = vector.y + "px";
-    };
+    }
 
     BETA.Canvas.prototype.line = function (posA, posB, thickness, style)
     {
@@ -342,59 +342,71 @@
         this.context.lineTo(posB.x, posB.y);
         this.context.stroke();
         this.context.closePath();
-    };
+    }
 
     BETA.Canvas.prototype.rect = function (pos, size, style)
     {
         this.context.fillStyle = style;
         this.context.fillRect(pos.x, pos.y, size.x, size.y);
-    };
+    }
 
     BETA.Canvas.prototype.lineRect = function (pos, size, thickness, style)
     {
         this.context.strokeStyle = style;
         this.context.lineWidth = thickness;
         this.context.strokeRect(pos.x, pos.y, size.x, size.y);
-    };
+    }
+
+    BETA.Canvas.prototype.drawImage = function (img, pos, size)
+    {
+        if (size)
+        {
+            this.context.drawImage(img, pos.x, pos.y, size.x, size.y);
+        }
+        else
+        {
+            this.context.drawImage(img, pos.x, pos.y);
+        }
+    }
 
     BETA.Canvas.prototype.translate = function (x, y)
     {
         this.context.translate(x, y);
-    };
+    }
 
     BETA.Canvas.prototype.vectorTranslate = function (vector)
     {
         this.context.translate(vector.x, vector.y);
-    };
+    }
 
     BETA.Canvas.prototype.scale = function (x, y)
     {
         this.context.scale(x, y);
-    };
+    }
 
     BETA.Canvas.prototype.vectorScale = function (vector)
     {
         this.context.scale(vector.x, vector.y);
-    };
+    }
 
     BETA.Canvas.prototype.rotate = function (degrees)
     {
         this.context.rotate(degrees * Math.PI / 180);
-    };
+    }
 
     BETA.Canvas.prototype.rotateRad = function (radians)
     {
         this.context.rotate(radians);
-    };
+    }
 
     BETA.Canvas.prototype.save = function ()
     {
         this.context.save();
-    };
+    }
 
     BETA.Canvas.prototype.restore = function ()
     {
         this.context.restore();
-    };
+    }
 
 })();

--- a/BETA.js
+++ b/BETA.js
@@ -207,54 +207,94 @@
         v.x = x;
         v.y = y;
         return v;
-    };
+    }
 
     BETA.v = BETA.vector;
 
     BETA.vStringify = function (v)
     {
         return "(" + v.x + ", " + v.y + ")";
-    };
+    }
 
     BETA.vAdd = function (v1, v2)
     {
         return BETA.v(v1.x + v2.x, v1.y + v2.y);
-    };
+    }
 
     BETA.vSubtract = function (v1, v2)
     {
         return BETA.v(v1.x - v2.x, v1.y - v2.y);
-    };
+    }
 
     BETA.vScale = function (v1, v2)
     {
         return BETA.v(v1.x * v2.x, v1.y * v2.y);
-    };
+    }
 
     BETA.vDot = function (v1, v2)
     {
         return v1.x * v2.x + v1.y * v2.y;
-    };
+    }
 
     BETA.vScalarMult = function (v, s)
     {
         return BETA.v(v.x * s, v.y * s);
-    };
+    }
 
     BETA.vScalarDiv = function (v, s)
     {
         return BETA.v(v.x / s, v.y / s);
-    };
+    }
 
     BETA.vMagnitude = function (v)
     {
         return Math.sqrt(v.x * v.x + v.y * v.y);
-    };
+    }
 
     BETA.vNormalize = function (v)
     {
         return (v.x === 0 && v.y === 0) ? v : BETA.vScalarDiv(v, BETA.vMagnitude(v));
-    };
+    }
+
+    //------------IMAGE FUNCTIONS-------------\\
+
+    BETA.images = [];
+
+    var loadingImgs = 0;
+
+    BETA.loadImage = function (url)
+    {
+        loadingImgs++;
+        var img = document.createElement("img");
+        img.onload = function ()
+        {
+            BETA.assert(img.naturalWidth > 0, "Image is broken, URL: " + url);
+            loadingImgs--;
+            if (loadingImgs === 0 && typeof onAllLoaded === "function")
+            {
+                onAllLoaded();
+                onAllLoaded = null;
+            }
+        }
+        img.src = url;
+        BETA.images.push(img);
+
+        return img;
+    }
+
+    var onAllLoaded = null;
+
+    BETA.waitForImgLoad(callback)
+    {
+        if (loadingImgs === 0)
+        {
+            callback();
+        }
+        else
+        {
+            onAllLoaded = callback;
+        }
+    }
 
     //------------CANVAS INTERFACE------------\\
 


### PR DESCRIPTION
Adds an API for loading and rendering images, as well as an event handler for when all images have loaded.

This pull request implements:
`images` - an array of all images loaded through the API

`loadImage` - asynchronously fetches an `HTMLImageElement` from a provided URL, adds it to `images` and returns it.

`waitForImgLoad` - takes a callback, which it executes whenever all images in `images` have successfully loaded.

`Canvas#drawImage` - renders an `HTMLImageElement` on the canvas, optionally resizing it.
