### PR TITLE
More vector functions + design change

### DIFF
--- a/BETA.js
+++ b/BETA.js
@@ -259,6 +259,11 @@
         return (v.x === 0 && v.y === 0) ? v : BETA.vScalarDiv(v, BETA.vMagnitude(v));
     };
 
+    BETA.vAngle = function (vec)
+    {
+        return Math.atan2(vec.y, vec.x) * (180 / Math.PI);
+    };
+
     //------------IMAGE FUNCTIONS-------------\\
 
     BETA.images = [];

--- a/BETA.js
+++ b/BETA.js
@@ -273,6 +273,11 @@
         };
     };
 
+    BETA.vDistance = function (v1, v2)
+    {
+        return BETA.vMagnitude(BETA.vSubtract(v1, v2));
+    };
+
     //------------IMAGE FUNCTIONS-------------\\
 
     BETA.images = [];

--- a/BETA.js
+++ b/BETA.js
@@ -278,6 +278,11 @@
         return BETA.vMagnitude(BETA.vSubtract(v1, v2));
     };
 
+    BETA.vGridDist = function (v1, v2)
+    {
+        return Math.abs(v1.x - v2.x) + Math.abs(v1.y - v2.y);
+    };
+
     //------------IMAGE FUNCTIONS-------------\\
 
     BETA.images = [];

--- a/BETA.js
+++ b/BETA.js
@@ -203,6 +203,11 @@
 
     BETA.v = BETA.vector;
 
+    BETA.vCopy = function (v)
+    {
+        return { x: v.x, y: v.y };
+    };
+
     BETA.vStringify = function (v)
     {
         return "(" + v.x + ", " + v.y + ")";

--- a/BETA.js
+++ b/BETA.js
@@ -196,20 +196,9 @@
 
     //------------VECTOR FUNCTIONS------------\\
 
-    BETA.vProto = {
-        toString: function ()
-        {
-            return BETA.vStringify(this);
-        }
-    };
-
     BETA.vector = function (x, y)
     {
-        //Vectors inherit .toString() from vProto
-        var v = Object.create(BETA.vProto);
-        v.x = x;
-        v.y = y;
-        return v;
+        return { x: x, y: y };
     };
 
     BETA.v = BETA.vector;
@@ -221,17 +210,26 @@
 
     BETA.vAdd = function (v1, v2)
     {
-        return BETA.v(v1.x + v2.x, v1.y + v2.y);
+        return {
+            x: v1.x + v2.x,
+            y: v1.y + v2.y
+        };
     };
 
     BETA.vSubtract = function (v1, v2)
     {
-        return BETA.v(v1.x - v2.x, v1.y - v2.y);
+        return {
+            x: v1.x - v2.x,
+            y: v1.y - v2.y
+        };
     };
 
     BETA.vScale = function (v1, v2)
     {
-        return BETA.v(v1.x * v2.x, v1.y * v2.y);
+        return {
+            x: v1.x * v2.x,
+            y: v1.y * v2.y
+        };
     };
 
     BETA.vDot = function (v1, v2)
@@ -241,12 +239,18 @@
 
     BETA.vScalarMult = function (v, s)
     {
-        return BETA.v(v.x * s, v.y * s);
+        return {
+            x: v.x * s,
+            y: v.y * s
+        };
     };
 
     BETA.vScalarDiv = function (v, s)
     {
-        return BETA.v(v.x / s, v.y / s);
+        return {
+            x: v.x / s,
+            y: v.y / s
+        };
     };
 
     BETA.vMagnitude = function (v)
@@ -256,7 +260,9 @@
 
     BETA.vNormalize = function (v)
     {
-        return (v.x === 0 && v.y === 0) ? v : BETA.vScalarDiv(v, BETA.vMagnitude(v));
+        return (v.x === 0 && v.y === 0) ?
+            v :
+            BETA.vScalarDiv(v, BETA.vMagnitude(v));
     };
 
     BETA.vAngle = function (vec)
@@ -353,7 +359,7 @@
         renderer.context = context;
         renderer.width = canvas.width;
         renderer.height = canvas.height;
-        renderer.size = BETA.v(canvas.width, canvas.height);
+        renderer.size = { x: canvas.width, y: canvas.height };
 
         return renderer;
     };
@@ -362,7 +368,7 @@
     {
         this.width = x;
         this.height = y;
-        this.size = BETA.v(x, y);
+        this.size = { x: x, y: y };
         this.canvas.width = x;
         this.canvas.height = y;
         this.canvas.style.width = x + "px";
@@ -756,8 +762,9 @@
     {
         BETA.assert(inputInitiated, "getMousePos(): You haven't initiated the input system yet!");
         var rect = this.canvas.getBoundingClientRect();
-        return BETA.v(
-            Math.round(mousePos.x - rect.left),
-            Math.round(mousePos.y - rect.top));
+        return {
+            x: Math.round(mousePos.x - rect.left),
+            y: Math.round(mousePos.y - rect.top)
+        };
     };
 }());

--- a/BETA.js
+++ b/BETA.js
@@ -283,6 +283,21 @@
         return Math.abs(v1.x - v2.x) + Math.abs(v1.y - v2.y);
     };
 
+    BETA.vRotate = function (vec, pivot, angle)
+    {
+        var radians = angle * (Math.PI / 180);
+        var sin = Math.sin(radians);
+        var cos = Math.cos(radians);
+        var dx = vec.x - pivot.x;
+        var dy = vec.y - pivot.y;
+        var rx = dx * cos - dy * sin;
+        var ry = dx * sin + dy * cos;
+        return {
+            x: rx + pivot.x,
+            y: ry + pivot.y
+        };
+    };
+
     //------------IMAGE FUNCTIONS-------------\\
 
     BETA.images = [];

--- a/BETA.js
+++ b/BETA.js
@@ -264,6 +264,15 @@
         return Math.atan2(vec.y, vec.x) * (180 / Math.PI);
     };
 
+    BETA.vFromPolar = function (radius, angle)
+    {
+        var radians = angle * (Math.PI / 180);
+        return {
+            x: Math.cos(radians) * radius,
+            y: Math.sin(radians) * radius
+        };
+    };
+
     //------------IMAGE FUNCTIONS-------------\\
 
     BETA.images = [];


### PR DESCRIPTION
Includes six new vector-related functions:
`vCopy` - copies the x and y components of a vector
`vAngle` - gets the angle of a vector
`vFromPolar` - constructs a vector from polar coordinates
`vDistance` - gets the euclidean distance between two vectors
`vGridDist` - gets the taxicab distance between two vector
`vRotate` - returns a vector rotated around some pivot point

Moreover, `vProto` has been removed, and vectors constucted by library functions consequently no longer inherit an overridden `toString` method.
The reason was to eliminate the difference from manually constucted vectors, so that object literals are equally viable as vectors.
All library calls to `vector/v` have therefore been replaced with object literals to enable engine optimization and editor autocompletion features.
