### PR TITLE
Bug fix + comment cleanup

### DIFF
--- a/BETA.js
+++ b/BETA.js
@@ -126,7 +126,6 @@
         return BETA.hsla(hue, saturation, lightness, 1);
     };
 
-    //Adapted from http://alvyray.com/Papers/CG/hsv2rgb.htm
     BETA.hsva = function (hue, saturation, value, alpha)
     {
         var h = BETA.mod(hue, 360) / 60;
@@ -159,7 +158,6 @@
         return BETA.hsva(hue, saturation, value, 1);
     };
 
-    //Adapted from http://alvyray.com/Papers/CG/hwb2rgb.htm
     BETA.hwba = function (hue, whiteness, blackness, alpha)
     {
         var h = BETA.mod(hue, 360) / 60;

--- a/BETA.js
+++ b/BETA.js
@@ -630,7 +630,7 @@
     //-------------INPUT HANDLING-------------\\
 
     var keyCodes = {
-        a: 65, b: 66, c: 67, d: 68, e: 69, f: 70, g: 71, h: 72, i: 73, j: 74, k: 75, lightness: 76, m: 77,
+        a: 65, b: 66, c: 67, d: 68, e: 69, f: 70, g: 71, h: 72, i: 73, j: 74, k: 75, l: 76, m: 77,
         n: 78, o: 79, p: 80, q: 81, r: 82, s: 83, t: 84, u: 85, v: 86, w: 87, x: 88, y: 89, z: 90,
         num0: 48, num1: 49, num2: 50, num3: 51, num4: 52, num5: 53, num6: 54, num7: 55, num8: 56, num9: 57,
         space: 32, enter: 13, tab: 9, esc: 27, backspace: 8, shift: 16, ctrl: 17, alt: 18,


### PR DESCRIPTION
A search-replace error had caused the L key to be named 'lightness' in the key table, fixed now.

Also, the comments crediting Alvy Smith's papers for HSL and HWB conversion have been removed, since he is now credited in the documentation.
