### PR TITLE
Add vComplexMult

### DIFF
--- a/BETA.d.ts
+++ b/BETA.d.ts
@@ -67,6 +67,8 @@ declare namespace BETA
 
     function vDot(v1: Vector, v2: Vector): Vector;
 
+    function vComplexMult(v1: Vector, v2: Vector): Vector;
+
     function vScalarMult(v: Vector, s: number): Vector;
 
     function vScalarDiv(v: Vector, s: number): Vector;

--- a/BETA.js
+++ b/BETA.js
@@ -246,6 +246,14 @@
         return v1.x * v2.x + v1.y * v2.y;
     };
 
+    BETA.vComplexMult = function (v1, v2)
+    {
+        return {
+            x: v1.x * v2.x - v1.y * v2.y,
+            y: v1.x * v2.y + v2.x * v1.y
+        };
+    };
+
     BETA.vScalarMult = function (v, s)
     {
         return {


### PR DESCRIPTION
Multiplies two vector as if they were complex numbers, treating the x-component as the real part and the y-component as the imaginary part.  
I've heard it's [useful for rotation](http://blog.demofox.org/2014/12/27/using-imaginary-numbers-to-rotate-2d-vectors/), someone might use it sometime.
#### `vComplexMult(`(_x_<sub>1</sub>, _y_<sub>1</sub>), (_x_<sub>2</sub>, _y_<sub>2</sub>)`)`= (_x_<sub>3</sub>, _y_<sub>3</sub>)   ↔   (_x_<sub>1</sub> + _y_<sub>1</sub>_i_) \* (_x_<sub>2</sub> + _y_<sub>2</sub>_i_) = (_x_<sub>3</sub> + _y_<sub>3</sub>_i_)
