### PR TITLE
Add getTextWidth

### DIFF
--- a/BETA.d.ts
+++ b/BETA.d.ts
@@ -146,6 +146,7 @@ declare namespace BETA
         drawImage(img: HTMLImageElement | HTMLVideoElement | HTMLCanvasElement, pos: Vector, size?: Vector): void;
 
         text(pos: Vector, text: string, font: string, size: number, color: CanvasStyle): void;
+        getTextWidth(text: string, font: string, size: number): number;
     }
 
     function getRenderer(id: string): CanvasRenderer;

--- a/BETA.js
+++ b/BETA.js
@@ -559,6 +559,12 @@
         this.context.fillText(text, pos.x, pos.y);
     };
 
+    canvasRendererProto.getTextWidth(text, font, size)
+    {
+        this.context.font = size + "px " + font;
+        return this.context.measureText(text).width;
+    }
+
     canvasRendererProto.translate = function (x, y)
     {
         this.context.translate(x, y);


### PR DESCRIPTION
Adds `CanvasRenderer#getTextWidth(text, font, size)`, which does exactly that - measures text width.
Useful for aligning/centering text.

Resolves #15.
