### PR TITLE
Fix syntax error in getTextWidth definition

### DIFF
--- a/BETA.js
+++ b/BETA.js
@@ -559,11 +559,11 @@
         this.context.fillText(text, pos.x, pos.y);
     };
 
-    canvasRendererProto.getTextWidth(text, font, size)
+    canvasRendererProto.getTextWidth = function (text, font, size)
     {
         this.context.font = size + "px " + font;
         return this.context.measureText(text).width;
-    }
+    };
 
     canvasRendererProto.translate = function (x, y)
     {


### PR DESCRIPTION
This is what happens when you forget to test.
Don't not test, kids!
