### PR TITLE
Add error-checking for getRenderer element

### DIFF
--- a/BETA.d.ts
+++ b/BETA.d.ts
@@ -1,6 +1,6 @@
 declare namespace BETA
 {
-    function assert(assertion: boolean, message: string): void;
+    function assert(assertion: boolean, message?: string): void;
 
     function isNumber(val: any): boolean;
 

--- a/BETA.js
+++ b/BETA.js
@@ -368,6 +368,7 @@
     BETA.getRenderer = function (id)
     {
         var canvas = document.getElementById(id);
+        BETA.assert(canvas instanceof HTMLCanvasElement, "getRenderer(): Element #" + id + " is not a <canvas>");
         var context = canvas.getContext("2d");
 
         var renderer = Object.create(canvasRendererProto);

--- a/BETA.js
+++ b/BETA.js
@@ -16,7 +16,7 @@
         if (!assertion)
         {
             var msg = (message) ?
-                "Assertion failed: " + message :
+                message :
                 "Assertion failed.";
             throw new Error(msg);
         }


### PR DESCRIPTION
Now throws an error if the provided ID doesn't refer to a `<canvas>` element.

Also removed the "Assertion Failed:" prefix on all `assert` errors, because there were just [too many colons](http://tvtropes.org/pmwiki/pmwiki.php/Main/ColonCancer). Even fixed a little typescript definition mistake while I was at it.
